### PR TITLE
tilbyr buildere for bakoverkompatibilitet

### DIFF
--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteOppfolgingsperiodeV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteOppfolgingsperiodeV1.kt
@@ -8,5 +8,24 @@ data class SisteOppfolgingsperiodeV1(
     val aktorId: String? = null,
     val startDato: ZonedDateTime? = null,
     val sluttDato: ZonedDateTime? = null,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var uuid: UUID? = null
+        private var aktorId: String? = null
+        private var startDato: ZonedDateTime? = null
+        private var sluttDato: ZonedDateTime? = null
+
+        fun uuid(uuid: UUID?): Builder = apply { this.uuid = uuid }
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun startDato(startDato: ZonedDateTime?): Builder = apply { this.startDato = startDato }
+        fun sluttDato(sluttDato: ZonedDateTime?): Builder = apply { this.sluttDato = sluttDato }
+
+        fun build(): SisteOppfolgingsperiodeV1 = SisteOppfolgingsperiodeV1(uuid, aktorId, startDato, sluttDato)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteOppfolgingsperiodeV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteOppfolgingsperiodeV1.kt
@@ -25,7 +25,12 @@ data class SisteOppfolgingsperiodeV1(
         fun startDato(startDato: ZonedDateTime?): Builder = apply { this.startDato = startDato }
         fun sluttDato(sluttDato: ZonedDateTime?): Builder = apply { this.sluttDato = sluttDato }
 
-        fun build(): SisteOppfolgingsperiodeV1 = SisteOppfolgingsperiodeV1(uuid, aktorId, startDato, sluttDato)
+        fun build(): SisteOppfolgingsperiodeV1 = SisteOppfolgingsperiodeV1(
+            uuid = uuid,
+            aktorId = aktorId,
+            startDato = startDato,
+            sluttDato = sluttDato,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteTilordnetVeilederV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteTilordnetVeilederV1.kt
@@ -6,5 +6,22 @@ data class SisteTilordnetVeilederV1(
     val aktorId: String? = null,
     val veilederId: String? = null,
     val tilordnet: ZonedDateTime? = null,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var veilederId: String? = null
+        private var tilordnet: ZonedDateTime? = null
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun veilederId(veilederId: String?): Builder = apply { this.veilederId = veilederId }
+        fun tilordnet(tilordnet: ZonedDateTime?): Builder = apply { this.tilordnet = tilordnet }
+
+        fun build(): SisteTilordnetVeilederV1 = SisteTilordnetVeilederV1(aktorId, veilederId, tilordnet)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteTilordnetVeilederV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/SisteTilordnetVeilederV1.kt
@@ -21,7 +21,11 @@ data class SisteTilordnetVeilederV1(
         fun veilederId(veilederId: String?): Builder = apply { this.veilederId = veilederId }
         fun tilordnet(tilordnet: ZonedDateTime?): Builder = apply { this.tilordnet = tilordnet }
 
-        fun build(): SisteTilordnetVeilederV1 = SisteTilordnetVeilederV1(aktorId, veilederId, tilordnet)
+        fun build(): SisteTilordnetVeilederV1 = SisteTilordnetVeilederV1(
+            aktorId = aktorId,
+            veilederId = veilederId,
+            tilordnet = tilordnet,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaMalV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaMalV1.kt
@@ -29,7 +29,12 @@ data class EndringPaMalV1(
         fun lagtInnAv(lagtInnAv: InnsenderData?): Builder = apply { this.lagtInnAv = lagtInnAv }
         fun veilederIdent(veilederIdent: String?): Builder = apply { this.veilederIdent = veilederIdent }
 
-        fun build(): EndringPaMalV1 = EndringPaMalV1(aktorId!!, endretTidspunk!!, lagtInnAv!!, veilederIdent)
+        fun build(): EndringPaMalV1 = EndringPaMalV1(
+            aktorId = aktorId!!,
+            endretTidspunk = endretTidspunk!!,
+            lagtInnAv = lagtInnAv!!,
+            veilederIdent = veilederIdent,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaMalV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaMalV1.kt
@@ -12,5 +12,24 @@ data class EndringPaMalV1(
         BRUKER,
         NAV
     }
+
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var endretTidspunk: ZonedDateTime? = null
+        private var lagtInnAv: InnsenderData? = null
+        private var veilederIdent: String? = null
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun endretTidspunk(endretTidspunk: ZonedDateTime?): Builder = apply { this.endretTidspunk = endretTidspunk }
+        fun lagtInnAv(lagtInnAv: InnsenderData?): Builder = apply { this.lagtInnAv = lagtInnAv }
+        fun veilederIdent(veilederIdent: String?): Builder = apply { this.veilederIdent = veilederIdent }
+
+        fun build(): EndringPaMalV1 = EndringPaMalV1(aktorId!!, endretTidspunk!!, lagtInnAv!!, veilederIdent)
+    }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaManuellStatusV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaManuellStatusV1.kt
@@ -16,7 +16,10 @@ data class EndringPaManuellStatusV1(
         fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
         fun erManuell(erManuell: Boolean): Builder = apply { this.erManuell = erManuell }
 
-        fun build(): EndringPaManuellStatusV1 = EndringPaManuellStatusV1(aktorId!!, erManuell)
+        fun build(): EndringPaManuellStatusV1 = EndringPaManuellStatusV1(
+            aktorId = aktorId!!,
+            erManuell = erManuell,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaManuellStatusV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaManuellStatusV1.kt
@@ -3,5 +3,20 @@ package no.nav.pto_schema.kafka.json.topic.onprem
 data class EndringPaManuellStatusV1(
     val aktorId: String,
     val erManuell: Boolean,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var erManuell: Boolean = false
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun erManuell(erManuell: Boolean): Builder = apply { this.erManuell = erManuell }
+
+        fun build(): EndringPaManuellStatusV1 = EndringPaManuellStatusV1(aktorId!!, erManuell)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaNyForVeilederV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaNyForVeilederV1.kt
@@ -16,7 +16,10 @@ data class EndringPaNyForVeilederV1(
         fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
         fun nyForVeileder(nyForVeileder: Boolean): Builder = apply { this.nyForVeileder = nyForVeileder }
 
-        fun build(): EndringPaNyForVeilederV1 = EndringPaNyForVeilederV1(aktorId!!, nyForVeileder)
+        fun build(): EndringPaNyForVeilederV1 = EndringPaNyForVeilederV1(
+            aktorId = aktorId!!,
+            nyForVeileder = nyForVeileder,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaNyForVeilederV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaNyForVeilederV1.kt
@@ -3,5 +3,20 @@ package no.nav.pto_schema.kafka.json.topic.onprem
 data class EndringPaNyForVeilederV1(
     val aktorId: String,
     val nyForVeileder: Boolean,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var nyForVeileder: Boolean = false
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun nyForVeileder(nyForVeileder: Boolean): Builder = apply { this.nyForVeileder = nyForVeileder }
+
+        fun build(): EndringPaNyForVeilederV1 = EndringPaNyForVeilederV1(aktorId!!, nyForVeileder)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaaOppfoelgingsBrukerV2.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaaOppfoelgingsBrukerV2.kt
@@ -67,22 +67,22 @@ data class EndringPaaOppfoelgingsBrukerV2(
         fun sistEndretDato(sistEndretDato: ZonedDateTime?): Builder = apply { this.sistEndretDato = sistEndretDato }
 
         fun build(): EndringPaaOppfoelgingsBrukerV2 = EndringPaaOppfoelgingsBrukerV2(
-            fodselsnummer!!,
-            formidlingsgruppe,
-            iservFraDato,
-            fornavn,
-            etternavn,
-            oppfolgingsenhet,
-            kvalifiseringsgruppe,
-            rettighetsgruppe,
-            hovedmaal,
-            sikkerhetstiltakType,
-            diskresjonskode,
-            harOppfolgingssak,
-            sperretAnsatt,
-            erDoed,
-            doedFraDato,
-            sistEndretDato,
+            fodselsnummer = fodselsnummer!!,
+            formidlingsgruppe = formidlingsgruppe,
+            iservFraDato = iservFraDato,
+            fornavn = fornavn,
+            etternavn = etternavn,
+            oppfolgingsenhet = oppfolgingsenhet,
+            kvalifiseringsgruppe = kvalifiseringsgruppe,
+            rettighetsgruppe = rettighetsgruppe,
+            hovedmaal = hovedmaal,
+            sikkerhetstiltakType = sikkerhetstiltakType,
+            diskresjonskode = diskresjonskode,
+            harOppfolgingssak = harOppfolgingssak,
+            sperretAnsatt = sperretAnsatt,
+            erDoed = erDoed,
+            doedFraDato = doedFraDato,
+            sistEndretDato = sistEndretDato,
         )
     }
 }

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaaOppfoelgingsBrukerV2.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/EndringPaaOppfoelgingsBrukerV2.kt
@@ -25,5 +25,65 @@ data class EndringPaaOppfoelgingsBrukerV2(
     val erDoed: Boolean? = null,
     val doedFraDato: LocalDate? = null,
     val sistEndretDato: ZonedDateTime? = null,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var fodselsnummer: String? = null
+        private var formidlingsgruppe: Formidlingsgruppe? = null
+        private var iservFraDato: LocalDate? = null
+        private var fornavn: String? = null
+        private var etternavn: String? = null
+        private var oppfolgingsenhet: String? = null
+        private var kvalifiseringsgruppe: Kvalifiseringsgruppe? = null
+        private var rettighetsgruppe: Rettighetsgruppe? = null
+        private var hovedmaal: Hovedmaal? = null
+        private var sikkerhetstiltakType: SikkerhetstiltakType? = null
+        private var diskresjonskode: String? = null
+        private var harOppfolgingssak: Boolean? = null
+        private var sperretAnsatt: Boolean? = null
+        private var erDoed: Boolean? = null
+        private var doedFraDato: LocalDate? = null
+        private var sistEndretDato: ZonedDateTime? = null
+
+        fun fodselsnummer(fodselsnummer: String?): Builder = apply { this.fodselsnummer = fodselsnummer }
+        fun formidlingsgruppe(formidlingsgruppe: Formidlingsgruppe?): Builder = apply { this.formidlingsgruppe = formidlingsgruppe }
+        fun iservFraDato(iservFraDato: LocalDate?): Builder = apply { this.iservFraDato = iservFraDato }
+        fun fornavn(fornavn: String?): Builder = apply { this.fornavn = fornavn }
+        fun etternavn(etternavn: String?): Builder = apply { this.etternavn = etternavn }
+        fun oppfolgingsenhet(oppfolgingsenhet: String?): Builder = apply { this.oppfolgingsenhet = oppfolgingsenhet }
+        fun kvalifiseringsgruppe(kvalifiseringsgruppe: Kvalifiseringsgruppe?): Builder = apply { this.kvalifiseringsgruppe = kvalifiseringsgruppe }
+        fun rettighetsgruppe(rettighetsgruppe: Rettighetsgruppe?): Builder = apply { this.rettighetsgruppe = rettighetsgruppe }
+        fun hovedmaal(hovedmaal: Hovedmaal?): Builder = apply { this.hovedmaal = hovedmaal }
+        fun sikkerhetstiltakType(sikkerhetstiltakType: SikkerhetstiltakType?): Builder = apply { this.sikkerhetstiltakType = sikkerhetstiltakType }
+        fun diskresjonskode(diskresjonskode: String?): Builder = apply { this.diskresjonskode = diskresjonskode }
+        fun harOppfolgingssak(harOppfolgingssak: Boolean?): Builder = apply { this.harOppfolgingssak = harOppfolgingssak }
+        fun sperretAnsatt(sperretAnsatt: Boolean?): Builder = apply { this.sperretAnsatt = sperretAnsatt }
+        fun erDoed(erDoed: Boolean?): Builder = apply { this.erDoed = erDoed }
+        fun doedFraDato(doedFraDato: LocalDate?): Builder = apply { this.doedFraDato = doedFraDato }
+        fun sistEndretDato(sistEndretDato: ZonedDateTime?): Builder = apply { this.sistEndretDato = sistEndretDato }
+
+        fun build(): EndringPaaOppfoelgingsBrukerV2 = EndringPaaOppfoelgingsBrukerV2(
+            fodselsnummer!!,
+            formidlingsgruppe,
+            iservFraDato,
+            fornavn,
+            etternavn,
+            oppfolgingsenhet,
+            kvalifiseringsgruppe,
+            rettighetsgruppe,
+            hovedmaal,
+            sikkerhetstiltakType,
+            diskresjonskode,
+            harOppfolgingssak,
+            sperretAnsatt,
+            erDoed,
+            doedFraDato,
+            sistEndretDato,
+        )
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpAvsluttetV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpAvsluttetV1.kt
@@ -7,5 +7,24 @@ data class KvpAvsluttetV1(
     val avsluttetAv: String? = null,
     val avsluttetDato: ZonedDateTime? = null,
     val avsluttetBegrunnelse: String? = null,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var avsluttetAv: String? = null
+        private var avsluttetDato: ZonedDateTime? = null
+        private var avsluttetBegrunnelse: String? = null
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun avsluttetAv(avsluttetAv: String?): Builder = apply { this.avsluttetAv = avsluttetAv }
+        fun avsluttetDato(avsluttetDato: ZonedDateTime?): Builder = apply { this.avsluttetDato = avsluttetDato }
+        fun avsluttetBegrunnelse(avsluttetBegrunnelse: String?): Builder = apply { this.avsluttetBegrunnelse = avsluttetBegrunnelse }
+
+        fun build(): KvpAvsluttetV1 = KvpAvsluttetV1(aktorId!!, avsluttetAv, avsluttetDato, avsluttetBegrunnelse)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpAvsluttetV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpAvsluttetV1.kt
@@ -24,7 +24,12 @@ data class KvpAvsluttetV1(
         fun avsluttetDato(avsluttetDato: ZonedDateTime?): Builder = apply { this.avsluttetDato = avsluttetDato }
         fun avsluttetBegrunnelse(avsluttetBegrunnelse: String?): Builder = apply { this.avsluttetBegrunnelse = avsluttetBegrunnelse }
 
-        fun build(): KvpAvsluttetV1 = KvpAvsluttetV1(aktorId!!, avsluttetAv, avsluttetDato, avsluttetBegrunnelse)
+        fun build(): KvpAvsluttetV1 = KvpAvsluttetV1(
+            aktorId = aktorId!!,
+            avsluttetAv = avsluttetAv,
+            avsluttetDato = avsluttetDato,
+            avsluttetBegrunnelse = avsluttetBegrunnelse,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpStartetV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpStartetV1.kt
@@ -8,5 +8,26 @@ data class KvpStartetV1(
     val opprettetAv: String? = null,
     val opprettetDato: ZonedDateTime? = null,
     val opprettetBegrunnelse: String? = null,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var enhetId: String? = null
+        private var opprettetAv: String? = null
+        private var opprettetDato: ZonedDateTime? = null
+        private var opprettetBegrunnelse: String? = null
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun enhetId(enhetId: String?): Builder = apply { this.enhetId = enhetId }
+        fun opprettetAv(opprettetAv: String?): Builder = apply { this.opprettetAv = opprettetAv }
+        fun opprettetDato(opprettetDato: ZonedDateTime?): Builder = apply { this.opprettetDato = opprettetDato }
+        fun opprettetBegrunnelse(opprettetBegrunnelse: String?): Builder = apply { this.opprettetBegrunnelse = opprettetBegrunnelse }
+
+        fun build(): KvpStartetV1 = KvpStartetV1(aktorId!!, enhetId, opprettetAv, opprettetDato, opprettetBegrunnelse)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpStartetV1.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/KvpStartetV1.kt
@@ -27,7 +27,13 @@ data class KvpStartetV1(
         fun opprettetDato(opprettetDato: ZonedDateTime?): Builder = apply { this.opprettetDato = opprettetDato }
         fun opprettetBegrunnelse(opprettetBegrunnelse: String?): Builder = apply { this.opprettetBegrunnelse = opprettetBegrunnelse }
 
-        fun build(): KvpStartetV1 = KvpStartetV1(aktorId!!, enhetId, opprettetAv, opprettetDato, opprettetBegrunnelse)
+        fun build(): KvpStartetV1 = KvpStartetV1(
+            aktorId = aktorId!!,
+            enhetId = enhetId,
+            opprettetAv = opprettetAv,
+            opprettetDato = opprettetDato,
+            opprettetBegrunnelse = opprettetBegrunnelse,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/VeilederTilordnetV2.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/VeilederTilordnetV2.kt
@@ -6,5 +6,22 @@ data class VeilederTilordnetV2(
     val aktorId: String,
     val veilederId: String? = null,
     val tilordnetTidspunkt: ZonedDateTime? = null,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var aktorId: String? = null
+        private var veilederId: String? = null
+        private var tilordnetTidspunkt: ZonedDateTime? = null
+
+        fun aktorId(aktorId: String?): Builder = apply { this.aktorId = aktorId }
+        fun veilederId(veilederId: String?): Builder = apply { this.veilederId = veilederId }
+        fun tilordnetTidspunkt(tilordnetTidspunkt: ZonedDateTime?): Builder = apply { this.tilordnetTidspunkt = tilordnetTidspunkt }
+
+        fun build(): VeilederTilordnetV2 = VeilederTilordnetV2(aktorId!!, veilederId, tilordnetTidspunkt)
+    }
+}
 

--- a/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/VeilederTilordnetV2.kt
+++ b/src/main/kotlin/no/nav/pto_schema/kafka/json/topic/onprem/VeilederTilordnetV2.kt
@@ -21,7 +21,11 @@ data class VeilederTilordnetV2(
         fun veilederId(veilederId: String?): Builder = apply { this.veilederId = veilederId }
         fun tilordnetTidspunkt(tilordnetTidspunkt: ZonedDateTime?): Builder = apply { this.tilordnetTidspunkt = tilordnetTidspunkt }
 
-        fun build(): VeilederTilordnetV2 = VeilederTilordnetV2(aktorId!!, veilederId, tilordnetTidspunkt)
+        fun build(): VeilederTilordnetV2 = VeilederTilordnetV2(
+            aktorId = aktorId!!,
+            veilederId = veilederId,
+            tilordnetTidspunkt = tilordnetTidspunkt,
+        )
     }
 }
 


### PR DESCRIPTION
Da jeg skrev om til kotlin og kastet ut lombok lot jeg være å lage buildere, for jeg tenkte at vi fint kan bruke konstruktørene direkte. I java-apper der man ikke har named parameters ser jeg at risikoen for feil er ganske stor for de litt større klassene som tar inn flere parametre av samme type. Jeg har derfor lagt til tradisjonelle buildere. 